### PR TITLE
refactor(http): rename headers() to create_request()

### DIFF
--- a/src/lib/protocol/http_ginga.lua
+++ b/src/lib/protocol/http_ginga.lua
@@ -75,7 +75,7 @@ local http_util = require('src/lib/util/http')
 --! @cond
 local function http_connect(self)
     local params = http_util.url_search_param(self.param_list, self.param_dict)
-    local headers = http_util.headers(self.header_list, self.header_dict, {
+    local headers = http_util.create_request(self.header_list, self.header_dict, {
         'Host', self.p_host..params, false,
         'Accept', '*/*', true,
         'Cache-Control', 'max-age=0', false,

--- a/src/lib/util/http.lua
+++ b/src/lib/util/http.lua
@@ -22,7 +22,7 @@ local function url_search_param(param_list, param_dict)
 end
 
 --! @todo document this function
-local function headers(header_list, header_dict, config)
+local function create_request(header_list, header_dict, config)
     local headers = ''
 
     if not header_list or not header_dict then
@@ -57,5 +57,5 @@ return {
     is_ok=is_ok,
     is_redirect=is_redirect,
     url_search_param=url_search_param,
-    headers=headers
+    create_request=create_request
 }


### PR DESCRIPTION
Renaming `http_util.headers()` to `http_util.create_request()`, as mentioned in issue #52.